### PR TITLE
Simplified 'scriptLog'

### DIFF
--- a/Elevate.sh
+++ b/Elevate.sh
@@ -30,13 +30,14 @@ scriptVersion="1.0.3"
 # Parameter 4: Reverse Domain Name Notation (i.e., "xyz.techitout")
 plistDomain="${4:-"com.company"}"
 
-# Parameter 5: Script Log Location (i.e., "/private/var/log")
-scriptLogLocation="${5:-"/private/var/log"}"
-scriptLog="${scriptLogLocation}/${plistDomain}.log"
-
-# Parameter 6: Elevation Duration (in minutes)
-elevationDurationMinutes="${6:-"1"}"
+# Parameter 5: Elevation Duration (in minutes)
+elevationDurationMinutes="${5:-"1"}"
 elevationDurationSeconds=$(( elevationDurationMinutes * 60 ))
+
+# Script Log Location (based on $plistDomain)
+scriptLog="/private/var/log/${plistDomain}.log"
+
+
 
 ##################################################
 # Remove old artifacts, if any ...


### PR DESCRIPTION
@robjschroeder:

Here's another two cents on `scriptLog`.

(I was concerned that I was going to enter `/var/log/org.churchofjesuschrist.log` for Parameter `5` and then I'd end up with the log at: `/var/log/org.churchofjesuschrist.log/org.churchofjesuschrist.log`.)