### PR TITLE
2.0.5: Added permissions correction on 'mktemp'-created files

### DIFF
--- a/Elevate.sh
+++ b/Elevate.sh
@@ -68,6 +68,10 @@
 # Version: 2.0.4
 # - Silenced the output of the creation of the Launch Daemon to declutter Jamf Pro policy logs (thanks @dan-snelson!)
 #
+# Updated 08.17.2023 @dan-snelson
+# Version 2.0.5
+# - Added permissions correction on `mktemp`-created files (for swiftDialog 2.3)
+#
 ##################################################
 
 ####################################################################################################
@@ -80,7 +84,7 @@
 # Script Version and Jamf Pro Script Parameters
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
-scriptVersion="2.0.4"
+scriptVersion="2.0.5"
 scriptFunctionalName="Elevate"
 export PATH=/usr/bin:/bin:/usr/sbin:/sbin
 
@@ -476,12 +480,14 @@ dialogVersion=$( /usr/local/bin/dialog --version )
 # Set Dialog path, Command Files, JAMF binary, log files and currently logged-in user
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
-dialogApp="/Library/Application\ Support/Dialog/Dialog.app/Contents/MacOS/Dialog"
-dialogBinary="/usr/local/bin/dialog"
-adminCommandFile=$( mktemp -u /var/tmp/dialogAdmin.XXX )
-promptCommandFile=$( mktemp -u /var/tmp/dialogPrompt.XXX )
-promptJSONFile=$( mktemp -u /var/tmp/promptJSONFile.XXX )
 jamfBinary="/usr/local/bin/jamf"
+dialogBinary="/usr/local/bin/dialog"
+promptJSONFile=$( mktemp /var/tmp/promptJSONFile.XXX )
+adminCommandFile=$( mktemp /var/tmp/dialogCommandFileAdmin.XXX )
+promptCommandFile=$( mktemp /var/tmp/dialogCommandFilePrompt.XXX )
+
+# Set permissions on Dialog Command Files
+chmod -v 555 /var/tmp/dialogCommandFile*
 
 osVersion=$( sw_vers -productVersion )
 osBuild=$( sw_vers -buildVersion )

--- a/Elevate.sh
+++ b/Elevate.sh
@@ -930,7 +930,7 @@ checkIfAdmin
 
 # Display prompt dialog
 echo $promptJSON > $promptJSONFile
-promptResults=$( eval "$dialogBinary --jsonfile ${promptJSONFile} --json" )
+promptResults=$( eval "$dialogBinary --jsonfile ${promptJSONFile} --json" | sed 's/ERROR: Unable to delete command file//g' )
 
 # Evaluate User Input
 if [[ -z "${promptResults}" ]]; then

--- a/Elevate.sh
+++ b/Elevate.sh
@@ -212,13 +212,13 @@ updateScriptLog "PRE-FLIGHT CHECK (${scriptFunctionalName}): Current Logged-in U
 # Pre-flight Check: Validate Operating System Version
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
-# Since swiftDialog requires at least macOS 11 Big Sur, first confirm the major OS version
-if [[ "${osMajorVersion}" -ge 11 ]] ; then
+# Since swiftDialog 2.3 requires at least macOS 12 Monterey, first confirm the major OS version
+if [[ "${osMajorVersion}" -ge 12 ]] ; then
     updateScriptLog "PRE-FLIGHT CHECK (${scriptFunctionalName}): macOS ${osMajorVersion} installed; continuing ..."
 else
-    # The Mac is running an operating system older than macOS 11 Big Sur; exit with error
-    updateScriptLog "PRE-FLIGHT CHECK (${scriptFunctionalName}): swiftDialog requires at least macOS 11 Big Sur and this Mac is running ${osVersion} (${osBuild}), exiting with error."
-    osascript -e 'display dialog "Please advise your Support Representative of the following error:\r\rExpected macOS 11 Big Sur (or newer), but found macOS '"${osVersion}"'.\r\r" with title "'${scriptFunctionalName}': Detected Outdated Operating System" buttons {"Open Software Update"} with icon caution'
+    # The Mac is running an operating system older than macOS 12 Monterey; exit with error
+    updateScriptLog "PRE-FLIGHT CHECK (${scriptFunctionalName}): swiftDialog 2.3 requires at least macOS 12 Monterey and this Mac is running ${osVersion} (${osBuild}), exiting with error."
+    osascript -e 'display dialog "Please advise your Support Representative of the following error:\r\rExpected macOS 12 Monterey (or newer), but found macOS '"${osVersion}"'.\r\r" with title "'${scriptFunctionalName}': Detected Outdated Operating System" buttons {"Open Software Update"} with icon caution'
     updateScriptLog "PRE-FLIGHT CHECK (${scriptFunctionalName}): Executing /usr/bin/open '/System/Library/CoreServices/Software Update.app' …"
     su - "${loggedInUser}" -c "/usr/bin/open /System/Library/CoreServices/Software Update.app"
     exit 1
@@ -487,7 +487,8 @@ adminCommandFile=$( mktemp /var/tmp/dialogCommandFileAdmin.XXX )
 promptCommandFile=$( mktemp /var/tmp/dialogCommandFilePrompt.XXX )
 
 # Set permissions on Dialog Command Files
-chmod -v 555 /var/tmp/dialogCommandFile*
+chmod -v 666 "${promptJSONFile}"
+chmod -v 666 /var/tmp/dialogCommandFile*
 
 osVersion=$( sw_vers -productVersion )
 osBuild=$( sw_vers -buildVersion )
@@ -616,11 +617,11 @@ function captureReason () {
 # Parse JSON via osascript and JavaScript
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
-function get_json_value() {
-    JSON="$1" osascript -l 'JavaScript' \
-        -e 'const env = $.NSProcessInfo.processInfo.environment.objectForKey("JSON").js' \
-        -e "JSON.parse(env).$2"
-}
+# function get_json_value() {
+#     JSON="$1" osascript -l 'JavaScript' \
+#         -e 'const env = $.NSProcessInfo.processInfo.environment.objectForKey("JSON").js' \
+#         -e "JSON.parse(env).$2"
+# }
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # Parse JSON via osascript and JavaScript for the Prompt dialog (thanks, @bartreardon!)


### PR DESCRIPTION
Needed for swiftDialog `2.3`.

(Most likely, swiftDialog `2.3` is a hard-requirement, as well.)